### PR TITLE
[FABRIC] 1.19.2 -  Bamboo tropical trapdoor recipe fix

### DIFF
--- a/1.19.2 fabric Trapdoors/src/main/resources/data/mcwtrpdoors/recipes/bamboo_tropical_trapdoor.json
+++ b/1.19.2 fabric Trapdoors/src/main/resources/data/mcwtrpdoors/recipes/bamboo_tropical_trapdoor.json
@@ -18,13 +18,13 @@
         
         "B":
         {
-            "item": "mcwtrpdoors:print_swamp"
+            "item": "mcwtrpdoors:print_tropical"
         }
     },
     
     "result":
     {
-        "item":  "mcwtrpdoors:bamboo_swamp_trapdoor",
+        "item":  "mcwtrpdoors:bamboo_tropical_trapdoor",
         "count": 1
     }
 }


### PR DESCRIPTION
Currently there is no way to craft bamboo tropical trapdoor since the recipe only resulting bamboo swamp trapdoor, this PR will fix the recipe as it should be