### PR TITLE
[FABRIC] 1.19.2 -  Mangrove bamboo trapdoor recipe fix

### DIFF
--- a/1.19.2 fabric Trapdoors/src/main/resources/data/mcwtrpdoors/recipes/mangrove_bamboo_trapdoor.json
+++ b/1.19.2 fabric Trapdoors/src/main/resources/data/mcwtrpdoors/recipes/mangrove_bamboo_trapdoor.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:warped_planks"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":
@@ -24,7 +24,7 @@
     
     "result":
     {
-        "item":  "mcwtrpdoors:warped_bamboo_trapdoor",
+        "item":  "mcwtrpdoors:mangrove_bamboo_trapdoor",
         "count": 1
     }
 }


### PR DESCRIPTION
Currently there is no way to craft mangrove bamboo trapdoor since the recipe only resulting bamboo swamp trapdoor, this PR will fix the recipe as it should be