### PR TITLE
Fix recipe unlock condition

### DIFF
--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:vine"
+            "items": ["minecraft:vine"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.16.5/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:vine"
+            "items": ["minecraft:vine"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.17.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:vine"
+            "items": ["minecraft:vine"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.18.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:vine"
+            "items": ["minecraft:vine"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:vine"
+            "items": ["minecraft:vine"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.18.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19.1/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19.2/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/1.19/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/acacia_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/birch_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/crimson_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/dark_oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/jungle_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/mangrove_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/oak_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/spruce_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/acacia/warped_bark_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo/bamboo_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/bamboo_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/birch/birch_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/crimson/crimson_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/dark_oak/dark_oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/jungle/jungle_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/mangrove/mangrove_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_full_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/metal/metal_warning_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:iron_ingot"
+            "items": ["minecraft:iron_ingot"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/oak/oak_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_barred.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_beach.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_classic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_cottage.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_four_panel.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_mystic.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_paper.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_swamp.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/print_tropical.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_mystic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/spruce/spruce_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barn_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_barred_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_beach_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_classic_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_cottage_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_four_panel_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_glass_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_paper_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_ranch_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_swamp_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
+++ b/fabric1.19.3/src/main/resources/data/mcwtrpdoors/advancements/recipes/warped/warped_tropical_trapdoor.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }


### PR DESCRIPTION
In Minecraft 1.19.2 (and likely every other version), picking up any item immediately unlocks all recipes added by this mod. This is unintentional, since the advancements specify only certain items should unlock it. This PR fixes that.

According to the [Minecraft wiki](https://minecraft.fandom.com/wiki/Advancement/JSON_format#minecraft:inventory_changed), the objects in the conditions.items array should contain a key named "items", not "item", whose value is an array of strings, not a single string.

These changes were made automatically using the following command in the Zsh shell on Linux (macOS's BSD variant of `sed` doesn't support the `-i` option as used here):
```zsh
sed -i -E 's/"item": (.+)/"items": [\1]/' **/advancements/**/*.json
```

You should be able to use this command to make the same changes to the rest of your mods; I have submitted PRs for only those mods I am personally using :)